### PR TITLE
Fix multi-byte filename

### DIFF
--- a/lib/libebook/ebook_chm.cpp
+++ b/lib/libebook/ebook_chm.cpp
@@ -585,7 +585,7 @@ bool EBook_CHM::parseFileAndFillArray( const QString& file, QList< ParsedEntry >
 bool EBook_CHM::ResolveObject(const QString& fileName, chmUnitInfo* ui) const
 {
 	return m_chmFile != NULL
-	       && ::chm_resolve_object(m_chmFile, qPrintable( fileName ), ui) ==
+	       && ::chm_resolve_object(m_chmFile, qUtf8Printable( fileName ), ui) ==
 	       CHM_RESOLVE_SUCCESS;
 }
 


### PR DESCRIPTION
Chm files with multi-byte file path are not shown under windows. Encode to utf-8.