### PR TITLE
Fix mbcs encodings

### DIFF
--- a/lib/libebook/ebook_chm.h
+++ b/lib/libebook/ebook_chm.h
@@ -201,8 +201,19 @@ class EBook_CHM : public EBook
 		class ParsedEntry
 		{
 			public:
-				ParsedEntry();
-
+				ParsedEntry()
+				{
+					iconid = EBookTocEntry::IMAGE_AUTO;
+					indent = 0;
+				}
+				void clear()
+				{
+					name.clear();
+					urls.clear();
+					iconid = EBookTocEntry::IMAGE_AUTO;
+					indent = 0;
+					seealso.clear();
+				}
 				QString     name;
 				QList<QUrl> urls;
 				int         iconid;
@@ -233,16 +244,16 @@ class EBook_CHM : public EBook
 
 		//! Encode the string from internal files with the currently selected text codec, if possible.
 		//! Or return as-is, if not.
-		inline QString encodeInternalWithCurrentCodec( const QString& str ) const
+		inline QString encodeInternalWithCurrentCodec( const QByteArray& str ) const
 		{
-			return ( m_textCodecForSpecialFiles ? m_textCodecForSpecialFiles->toUnicode( qPrintable( str ) ) : str );
+			return ( m_textCodecForInternalFiles ? m_textCodecForInternalFiles->toUnicode( str.constData() ) : str );
 		}
 
 		//! Encode the string from internal files with the currently selected text codec, if possible.
 		//! Or return as-is, if not.
 		inline QString encodeInternalWithCurrentCodec( const char* str ) const
 		{
-			return ( m_textCodecForSpecialFiles ? m_textCodecForSpecialFiles->toUnicode( str ) : ( QString ) str );
+			return ( m_textCodecForInternalFiles ? m_textCodecForInternalFiles->toUnicode( str ) : ( QString ) str );
 		}
 
 		//! Helper. Translates from Win32 encodings to generic wxWidgets ones.
@@ -251,8 +262,8 @@ class EBook_CHM : public EBook
 		//! Parse the HHC or HHS file, and fill the context (asIndex is false) or index (asIndex is true) array.
 		bool        parseFileAndFillArray( const QString& file, QList< ParsedEntry >& data, bool asIndex ) const;
 
-		bool        getBinaryContent( QByteArray& data, const QString& url ) const;
-		bool        getTextContent( QString& str, const QString& url, bool internal_encoding = false ) const;
+		bool        getTextContent( QString& str, const QString& path, bool internal_encoding = false ) const;
+		bool        getBinaryContent( QByteArray& data, const QString& path ) const;
 
 		/*!
 		 * Parse binary TOC
@@ -315,7 +326,7 @@ class EBook_CHM : public EBook
 
 		//! Chosen text codec
 		QTextCodec* m_textCodec;
-		QTextCodec* m_textCodecForSpecialFiles;
+		QTextCodec* m_textCodecForInternalFiles;
 
 		//! Current encoding
 		QString     m_currentEncoding;

--- a/src/dialog_topicselector.ui
+++ b/src/dialog_topicselector.ui
@@ -1,30 +1,31 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>DialogTopicSelector</class>
- <widget class="QDialog" name="DialogTopicSelector" >
-  <property name="geometry" >
+ <widget class="QDialog" name="DialogTopicSelector">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>218</width>
+    <width>360</width>
     <height>258</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Multiple topics</string>
   </property>
-  <layout class="QVBoxLayout" >
-   <property name="margin" >
+  <layout class="QVBoxLayout">
+   <property name="margin">
     <number>9</number>
    </property>
-   <property name="spacing" >
+   <property name="spacing">
     <number>6</number>
    </property>
    <item>
-    <widget class="QLabel" name="label" >
-     <property name="text" >
+    <widget class="QLabel" name="label">
+     <property name="text">
       <string>Please select the topic to open:</string>
      </property>
-     <property name="alignment" >
+     <property name="alignment">
       <set>Qt::AlignCenter</set>
      </property>
     </widget>
@@ -33,11 +34,11 @@
     <widget class="QListWidget" name="list" />
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox" >
-     <property name="orientation" >
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-     <property name="standardButtons" >
+     <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::NoButton|QDialogButtonBox::Ok</set>
      </property>
     </widget>
@@ -53,11 +54,11 @@
    <receiver>DialogTopicSelector</receiver>
    <slot>accept()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>66</x>
      <y>330</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>-3</x>
      <y>275</y>
     </hint>
@@ -69,11 +70,11 @@
    <receiver>DialogTopicSelector</receiver>
    <slot>reject()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>151</x>
      <y>327</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>277</x>
      <y>293</y>
     </hint>

--- a/src/qtwebengine/viewwindow.cpp
+++ b/src/qtwebengine/viewwindow.cpp
@@ -95,7 +95,7 @@ void ViewWindow::load( const QUrl& url )
 
 QString ViewWindow::title() const
 {
-	QString title = ::mainWindow->chmFile()->getTopicByUrl( url() );
+	QString title = QWebEngineView::title();  //::mainWindow->chmFile()->getTopicByUrl( url() );
 
 	// If no title is found, use the path (without the first /)
 	if ( title.isEmpty() )

--- a/src/qtwebkit/viewwindow.cpp
+++ b/src/qtwebkit/viewwindow.cpp
@@ -102,7 +102,7 @@ void ViewWindow::applySettings( BrowserSettings& settings )
 
 QString ViewWindow::title() const
 {
-	QString title = ::mainWindow->chmFile()->getTopicByUrl( url() );
+	QString title = QWebView::title();  //::mainWindow->chmFile()->getTopicByUrl( url() );
 
 	// If no title is found, use the path (without the first /)
 	if ( title.isEmpty() )

--- a/src/tab_index.cpp
+++ b/src/tab_index.cpp
@@ -91,7 +91,7 @@ void TabIndex::onTextChanged( const QString& newvalue )
 	{
 		m_lastSelectedItem = items[0];
 		tree->setCurrentItem( m_lastSelectedItem );
-		tree->scrollToItem( m_lastSelectedItem );
+		tree->scrollToItem( m_lastSelectedItem, QAbstractItemView::PositionAtTop );
 	}
 	else
 		m_lastSelectedItem = 0;


### PR DESCRIPTION
Fixed multiple encoding related issues, changes:
- Now selecting encoding in menu only changes text encoding, not internal encoding(the one to work with `#TOPICS`). Use options like `UTF-8/GBK` to change internal encoding. This should be less confusing, since internal encoding is auto detected and not supposed to change in most cases.
- Fix garbage in webview titles. Now extracted directly from html, not `#STRINGS`.
- Fix possible garbage strings when viewing source and searching html content.
- Index entries with multiple `Name` are supported.
- Index entries shares one `Name` are supported. They are merged into one tree item, and a selection dialog is shown on click(same behavior as `hh.exe`) .
- Index are sorted, in alphabet.
- Scroll to matching item to top when searching index.
- Naming fixes, etc.
