### PR TITLE
Improve CJK fonts rendering under Windows

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,10 @@
 	typedef QApplication  UchmviewerApp;
 #endif
 
+#ifdef _WIN32
+	#include <windows.h>
+#endif
+
 #if defined USE_DBUS
 	#include <QDBusConnection>
 	#include "dbus_interface.h"
@@ -44,6 +48,51 @@
 
 MainWindow* mainWindow;
 
+
+void fallbackFonts()
+{
+#ifdef _WIN32
+	// Obtain default GUI font (typically "Segoe UI, 9pt", see QTBUG-58610)
+	QFont systemFont = QApplication::font("QMessageBox");
+	LANGID lid = GetUserDefaultLangID();
+	QStringList result;
+	switch ( lid & 0xff )
+	{
+	case LANG_CHINESE:
+		if ( lid == 0x0804 || lid == 0x1004 )  // China mainland and Singapore
+			result << "Microsoft YaHei UI" << "Microsoft YaHei" << "Arial"
+				<< "Microsoft JhengHei UI" << "Microsoft JhengHei" << "Malgun Gothic" << "Yu Gothic UI" << "Meiryo UI"
+				<< "Yu Gothic" << "Meiryo";
+		else
+			result << "Microsoft JhengHei UI" << "Microsoft JhengHei" << "Arial"
+				<< "Microsoft YaHei UI" << "Microsoft YaHei" << "Malgun Gothic" << "Yu Gothic UI" << "Meiryo UI"
+				<< "Yu Gothic" << "Meiryo";
+		break;
+	case LANG_JAPANESE:
+		result << "Yu Gothic UI" << "Meiryo UI" << "Yu Gothic" << "Meiryo" << "Arial"
+			<< "Malgun Gothic" << "Microsoft YaHei UI" << "Microsoft YaHei" << "Microsoft JhengHei UI" << "Microsoft JhengHei";
+		break;
+	case LANG_KOREAN:
+		result << "Malgun Gothic" << "Arial"
+			<< "Microsoft JhengHei UI" << "Microsoft JhengHei" << "Microsoft YaHei UI" << "Microsoft YaHei"
+			<< "Yu Gothic UI" << "Meiryo UI" << "Yu Gothic" << "Meiryo";
+		break;
+	default:
+		result << "Arial" << "Yu Gothic UI" << "Meiryo UI" << "Yu Gothic" << "Meiryo" << "Malgun Gothic"
+			<< "Microsoft JhengHei UI" << "Microsoft JhengHei" << "Microsoft YaHei UI" << "Microsoft YaHei";
+		break;
+	}
+	result << "Nirmala UI"
+		<< "Iskoola Pota"
+		<< "Ebrima"
+		<< "Arial Unicode MS"
+		<< "Segoe UI Emoji"
+		<< "Segoe UI Symbol";
+	systemFont.insertSubstitutions(systemFont.family(), result);
+	systemFont.setHintingPreference(QFont::PreferNoHinting);
+	QApplication::setFont(systemFont);
+#endif
+}
 
 int main( int argc, char** argv )
 {
@@ -71,6 +120,8 @@ int main( int argc, char** argv )
 
 	app.addLibraryPath( "qt-plugins" );
 #endif
+
+	fallbackFonts();
 
 	app_i18n::init();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,44 +53,50 @@ void fallbackFonts()
 {
 #ifdef _WIN32
 	// Obtain default GUI font (typically "Segoe UI, 9pt", see QTBUG-58610)
-	QFont systemFont = QApplication::font("QMessageBox");
+	QFont systemFont = QApplication::font( "QMessageBox" );
 	LANGID lid = GetUserDefaultLangID();
 	QStringList result;
+
 	switch ( lid & 0xff )
 	{
 	case LANG_CHINESE:
 		if ( lid == 0x0804 || lid == 0x1004 )  // China mainland and Singapore
 			result << "Microsoft YaHei UI" << "Microsoft YaHei" << "Arial"
-				<< "Microsoft JhengHei UI" << "Microsoft JhengHei" << "Malgun Gothic" << "Yu Gothic UI" << "Meiryo UI"
-				<< "Yu Gothic" << "Meiryo";
+			       << "Microsoft JhengHei UI" << "Microsoft JhengHei" << "Malgun Gothic" << "Yu Gothic UI" << "Meiryo UI"
+			       << "Yu Gothic" << "Meiryo";
 		else
 			result << "Microsoft JhengHei UI" << "Microsoft JhengHei" << "Arial"
-				<< "Microsoft YaHei UI" << "Microsoft YaHei" << "Malgun Gothic" << "Yu Gothic UI" << "Meiryo UI"
-				<< "Yu Gothic" << "Meiryo";
+			       << "Microsoft YaHei UI" << "Microsoft YaHei" << "Malgun Gothic" << "Yu Gothic UI" << "Meiryo UI"
+			       << "Yu Gothic" << "Meiryo";
+
 		break;
+
 	case LANG_JAPANESE:
 		result << "Yu Gothic UI" << "Meiryo UI" << "Yu Gothic" << "Meiryo" << "Arial"
-			<< "Malgun Gothic" << "Microsoft YaHei UI" << "Microsoft YaHei" << "Microsoft JhengHei UI" << "Microsoft JhengHei";
+		       << "Malgun Gothic" << "Microsoft YaHei UI" << "Microsoft YaHei" << "Microsoft JhengHei UI" << "Microsoft JhengHei";
 		break;
+
 	case LANG_KOREAN:
 		result << "Malgun Gothic" << "Arial"
-			<< "Microsoft JhengHei UI" << "Microsoft JhengHei" << "Microsoft YaHei UI" << "Microsoft YaHei"
-			<< "Yu Gothic UI" << "Meiryo UI" << "Yu Gothic" << "Meiryo";
+		       << "Microsoft JhengHei UI" << "Microsoft JhengHei" << "Microsoft YaHei UI" << "Microsoft YaHei"
+		       << "Yu Gothic UI" << "Meiryo UI" << "Yu Gothic" << "Meiryo";
 		break;
+
 	default:
 		result << "Arial" << "Yu Gothic UI" << "Meiryo UI" << "Yu Gothic" << "Meiryo" << "Malgun Gothic"
-			<< "Microsoft JhengHei UI" << "Microsoft JhengHei" << "Microsoft YaHei UI" << "Microsoft YaHei";
+		       << "Microsoft JhengHei UI" << "Microsoft JhengHei" << "Microsoft YaHei UI" << "Microsoft YaHei";
 		break;
 	}
+
 	result << "Nirmala UI"
-		<< "Iskoola Pota"
-		<< "Ebrima"
-		<< "Arial Unicode MS"
-		<< "Segoe UI Emoji"
-		<< "Segoe UI Symbol";
-	systemFont.insertSubstitutions(systemFont.family(), result);
-	systemFont.setHintingPreference(QFont::PreferNoHinting);
-	QApplication::setFont(systemFont);
+	       << "Iskoola Pota"
+	       << "Ebrima"
+	       << "Arial Unicode MS"
+	       << "Segoe UI Emoji"
+	       << "Segoe UI Symbol";
+	systemFont.insertSubstitutions( systemFont.family(), result );
+	systemFont.setHintingPreference( QFont::PreferNoHinting );
+	QApplication::setFont( systemFont );
 #endif
 }
 


### PR DESCRIPTION
Blurry CJK fonts rendering under Windows, which seems to be a general issue. Adding fallback support for windows font handling when using CJK fonts.

See difference. The left is unpatched, the right is patched. The default UI font is changed from `MS Shell Dlg 2` to `Segoe UI` to align with Qt6 changes and modern Windows versions. Qt fallback to `SimSun` font by default when displaying Chinese. It now fallback to `Microsoft Yahei UI`, the default Windows font for Chinese display language.
![zh_cn_fonts2](https://github.com/user-attachments/assets/0876df2d-4e5d-42a4-a34a-0e6d5d4a9949)

Also the Japanese ones.
![jp_fonts2](https://github.com/user-attachments/assets/c38bba66-ad48-4175-8be4-195993451984)

Actually non-CJK fonts also render more smooth. Tested using Windows 11, with English/Chinese/Japanese set as display language.

The font list is taken from [telegram](https://github.com/desktop-app/patches/blob/master/qtbase_5.15.15/0003-fix-windows-font-fallback.patch). Also see: [QTBUG-58610](https://bugreports.qt.io/browse/QTBUG-58610).
